### PR TITLE
Enable sixel support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN sh autogen.sh
 ENV CPPFLAGS="-I$BUILD_DIR/AppDir/usr/include -I$BUILD_DIR/AppDir/usr/include/ncurses"
 ENV LDFLAGS="-L$BUILD_DIR/AppDir/usr/lib"
 ENV PKG_CONFIG_PATH=$BUILD_DIR/AppDir/usr/lib/pkgconfig
-RUN ./configure --prefix="$BUILD_DIR/AppDir/usr"
+RUN ./configure --prefix="$BUILD_DIR/AppDir/usr" --enable-sixel
 RUN make -j4 && make install
 
 ## Create Appimage

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export TMUX_RELEASE_TAG=3.4
+export TMUX_RELEASE_TAG="master"
 docker build . -t tmux --build-arg TMUX_RELEASE_TAG=$TMUX_RELEASE_TAG
 
 docker rm -f tmuxcontainer
@@ -8,4 +8,4 @@ docker create -ti --name tmuxcontainer tmux bash
 docker cp tmuxcontainer:/opt/build/tmux.appimage .
 docker rm -f tmuxcontainer
 
-zsyncmake -z tmux.appimage
+# zsyncmake -z tmux.appimage

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export TMUX_RELEASE_TAG=3.3a
+export TMUX_RELEASE_TAG=3.4
 docker build . -t tmux --build-arg TMUX_RELEASE_TAG=$TMUX_RELEASE_TAG
 
 docker rm -f tmuxcontainer


### PR DESCRIPTION
Some (many?) package repositories are providing `tmux` packages with Sixel support (`--enable-sixel` config flag). I checked both debian and arch.

I would understand if you don't want to merge this addition, but I think people might find it useful so I'm opening the PR. I also updated to tmux 3.4 and uploaded the built `tmux.appimage` to the fork — however given [recent news](https://arstechnica.com/security/2024/04/what-we-know-about-the-xz-utils-backdoor-that-almost-infected-the-world/) you may want to re-build it yourself 😅 .